### PR TITLE
more specific prose for math in recsys notebook 1.2

### DIFF
--- a/recommender systems/notebooks/1.2-movielens-model-based-recsys.ipynb
+++ b/recommender systems/notebooks/1.2-movielens-model-based-recsys.ipynb
@@ -245,19 +245,52 @@
     "\n",
     "The next step is to do matrix factorization. To do this we recall that the goal takes the form \n",
     "\n",
-    "$$L_{exp} = \\sum\\limits_{u,i \\in S}(r_{ui} - \\textbf{x}_{u}^{\\intercal} \\cdot{} \\textbf{y}_{i})^{2} + \\lambda_{x} \\sum\\limits_{u} \\left\\Vert \\textbf{x}_{u} \\right\\Vert^{2} + \\lambda_{y} \\sum\\limits_{u} \\left\\Vert \\textbf{y}_{i} \\right\\Vert^{2}$$\n",
+    "$$L_{\\text{exp}} = \\sum\\limits_{(u,i) \\in S}(r_{ui} - \\textbf{x}_{u}^{\\intercal} \\cdot{} \\textbf{y}_{i})^{2} + \\lambda_{x} \\sum\\limits_{u} \\left\\Vert \\textbf{x}_{u} \\right\\Vert^{2} + \\lambda_{y} \\sum\\limits_{u} \\left\\Vert \\textbf{y}_{i} \\right\\Vert^{2} \\tag{1}\\label{eq:1} $$\n",
     "\n",
-    "or more advanced,\n",
     "\n",
-    "$$L_{WRMF} = \\sum\\limits_{u,i}c_{ui} \\big( p_{ui} - \\textbf{x}_{u}^{\\intercal} \\cdot{} \\textbf{y}_{i} \\big) ^{2} + \\lambda_{x} \\sum\\limits_{u} \\left\\Vert \\textbf{x}_{u} \\right\\Vert^{2} + \\lambda_{y} \\sum\\limits_{u} \\left\\Vert \\textbf{y}_{i} \\right\\Vert^{2}$$\n",
+    "where $ S $ is the set of indices for which the corresponding element of the user-rating matrix, $ r_{ui} $, is not zero:\n",
     "\n",
-    "We only focussed on the first type and leave the second one as an exercise.\n",
+    "$$ S = \\{ (u,i) | r_{ui} \\neq 0 \\} \\tag{1.1}\\label{eq:1.1} $$\n",
     "\n",
-    "We create a class that will take care of the model, a class should be able to do train and inference. Recall that the update rule is given by:\n",
     "\n",
-    "$$ x_u = (M M^T + \\lambda_x \\mathbb{Id})^{-1} M R$$\n",
+    "A more more advanced, alternative is based on weighted regularized matrix factorization (WRMF): \n",
     "\n",
-    "**Exercise**: Understand the difference between this and the Netflix paper update rule."
+    "$$L_{\\text{WRMF}} = \\sum\\limits_{u,i}c_{ui} \\big( p_{ui} - \\textbf{x}_{u}^{\\intercal} \\cdot{} \\textbf{y}_{i} \\big) ^{2} + \\lambda_{x} \\sum\\limits_{u} \\left\\Vert \\textbf{x}_{u} \\right\\Vert^{2} + \\lambda_{y} \\sum\\limits_{u} \\left\\Vert \\textbf{y}_{i} \\right\\Vert^{2} \\tag{2}\\label{eq:2}  $$\n",
+    "\n",
+    "\n",
+    "where $ \\bf{P} $ is matrix of $ \\it{preferences} $, which is a binarizer of the matrix of ratings:\n",
+    "\n",
+    "$$\n",
+    "  p_{ij} =\n",
+    "  \\begin{cases}\n",
+    "                                   1 & \\text{if $r_{ij} > 0$} \\\\\n",
+    "                                   0 & \\text{otherwise} \n",
+    "  \\end{cases}\n",
+    "  \\tag{2.1}\\label{eq:2.1}\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "and $ \\bf{C} $ is the $ \\it{confidence} $ matrix , whose elements are a function of the elements of the matrix of ratings:\n",
+    "\n",
+    "$$\n",
+    "  c_{ij} = 1 + f(r_{ij})\n",
+    "  \\tag{2.2}\\label{eq:2.2}\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "We only focus on eq. (1) and leave the second approach, eq. (2), as an exercise.\n",
+    "\n",
+    "We create a class that will take care of the model, a class should be able to do train and inference. \n",
+    "\n",
+    "Recall that, for eq. (1), the update rule is, :\n",
+    "\n",
+    "$$ x_u = (Y^T Y + \\lambda_x \\mathbb{Id})^{-1} Y^T R \\tag{3}\\label{eq:3} $$\n",
+    "\n",
+    "\n",
+    "The update rule, eq. (3), takes a different form the cost function displayed in eq. (2). \n",
+    "\n",
+    "\n",
+    "**Exercise**: Understand the difference between the update given in the Netflix paper and the update corresponding to the cost function in eq. (2)"
    ]
   },
   {
@@ -567,9 +600,9 @@
    "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "recsys",
    "language": "python",
-   "name": "python3"
+   "name": "recsys"
   },
   "language_info": {
    "codemirror_mode": {
@@ -581,7 +614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Main changes proposed in _Matrix Factorization_ section of notebook 1.2 on recsys folder:

- Numbering equations for easier reference
- Changing sub-indices in eq. (1) and (3) from math to text type
- Specifying over which set the sum runs over in eq. (1) 
- Specifying what WRMF stands for.
- Specifying meaning of c_{ui} and p_{ui} in eq. (2) - it is not originally introduced
- More detailed comments on what is meant by "We only focussed on the first type and leave the second one as an exercise."
- Specifying what _M_ is (it never appears in any equation of that snipet
![PR-eq-recsys](https://user-images.githubusercontent.com/9633899/126920308-fd85d365-784a-4258-9b38-f6f38a067d18.PNG)
)